### PR TITLE
Fix incorrect case with SDLHMIZoneCapabilities

### DIFF
--- a/sdl_ios/SmartDeviceLink/SDLHMIZoneCapabilities.h
+++ b/sdl_ios/SmartDeviceLink/SDLHMIZoneCapabilities.h
@@ -5,12 +5,12 @@
 #import <Foundation/Foundation.h>
 #import <SmartDeviceLink/SDLEnum.h>
 
-@interface SDLHmiZoneCapabilities : SDLEnum {}
+@interface SDLHMIZoneCapabilities : SDLEnum {}
 
-+(SDLHmiZoneCapabilities*) valueOf:(NSString*) value;
++(SDLHMIZoneCapabilities*) valueOf:(NSString*) value;
 +(NSMutableArray*) values;
 
-+(SDLHmiZoneCapabilities*) FRONT;
-+(SDLHmiZoneCapabilities*) BACK;
++(SDLHMIZoneCapabilities*) FRONT;
++(SDLHMIZoneCapabilities*) BACK;
 
 @end

--- a/sdl_ios/SmartDeviceLink/SDLHMIZoneCapabilities.m
+++ b/sdl_ios/SmartDeviceLink/SDLHMIZoneCapabilities.m
@@ -1,18 +1,18 @@
-//  SDLHmiZoneCapabilities.m
+//  SDLHMIZoneCapabilities.m
 //
 //  Copyright (c) 2014 Ford Motor Company. All rights reserved.
 
-#import <SmartDeviceLink/SDLHmiZoneCapabilities.h>
+#import <SmartDeviceLink/SDLHMIZoneCapabilities.h>
 
-SDLHmiZoneCapabilities* SDLHmiZoneCapabilities_FRONT = nil;
-SDLHmiZoneCapabilities* SDLHmiZoneCapabilities_BACK = nil;
+static SDLHMIZoneCapabilities* SDLHMIZoneCapabilities_FRONT = nil;
+static SDLHMIZoneCapabilities* SDLHMIZoneCapabilities_BACK = nil;
 
-NSMutableArray* SDLHmiZoneCapabilities_values = nil;
+static NSMutableArray* SDLHMIZoneCapabilities_values = nil;
 
-@implementation SDLHmiZoneCapabilities
+@implementation SDLHMIZoneCapabilities
 
-+(SDLHmiZoneCapabilities*) valueOf:(NSString*) value {
-    for (SDLHmiZoneCapabilities* item in SDLHmiZoneCapabilities.values) {
++(SDLHMIZoneCapabilities*) valueOf:(NSString*) value {
+    for (SDLHMIZoneCapabilities* item in SDLHMIZoneCapabilities.values) {
         if ([item.value isEqualToString:value]) {
             return item;
         }
@@ -21,27 +21,27 @@ NSMutableArray* SDLHmiZoneCapabilities_values = nil;
 }
 
 +(NSMutableArray*) values {
-    if (SDLHmiZoneCapabilities_values == nil) {
-        SDLHmiZoneCapabilities_values = [[NSMutableArray alloc] initWithObjects:
-                SDLHmiZoneCapabilities.FRONT,
-                SDLHmiZoneCapabilities.BACK,
+    if (SDLHMIZoneCapabilities_values == nil) {
+        SDLHMIZoneCapabilities_values = [[NSMutableArray alloc] initWithObjects:
+                SDLHMIZoneCapabilities.FRONT,
+                SDLHMIZoneCapabilities.BACK,
                 nil];
     }
-    return SDLHmiZoneCapabilities_values;
+    return SDLHMIZoneCapabilities_values;
 }
 
-+(SDLHmiZoneCapabilities*) FRONT {
-    if (SDLHmiZoneCapabilities_FRONT == nil) {
-        SDLHmiZoneCapabilities_FRONT = [[SDLHmiZoneCapabilities alloc] initWithValue:@"FRONT"];
++(SDLHMIZoneCapabilities*) FRONT {
+    if (SDLHMIZoneCapabilities_FRONT == nil) {
+        SDLHMIZoneCapabilities_FRONT = [[SDLHMIZoneCapabilities alloc] initWithValue:@"FRONT"];
     }
-    return SDLHmiZoneCapabilities_FRONT;
+    return SDLHMIZoneCapabilities_FRONT;
 }
 
-+(SDLHmiZoneCapabilities*) BACK {
-    if (SDLHmiZoneCapabilities_BACK == nil) {
-        SDLHmiZoneCapabilities_BACK = [[SDLHmiZoneCapabilities alloc] initWithValue:@"BACK"];
++(SDLHMIZoneCapabilities*) BACK {
+    if (SDLHMIZoneCapabilities_BACK == nil) {
+        SDLHMIZoneCapabilities_BACK = [[SDLHMIZoneCapabilities alloc] initWithValue:@"BACK"];
     }
-    return SDLHmiZoneCapabilities_BACK;
+    return SDLHMIZoneCapabilities_BACK;
 }
 
 @end

--- a/sdl_ios/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
+++ b/sdl_ios/SmartDeviceLink/SDLRegisterAppInterfaceResponse.m
@@ -162,12 +162,12 @@
 
 -(NSMutableArray*) hmiZoneCapabilities {
     NSMutableArray* array = [parameters objectForKey:NAMES_hmiZoneCapabilities];
-    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLHmiZoneCapabilities.class]) {
+    if ([array count] < 1 || [[array objectAtIndex:0] isKindOfClass:SDLHMIZoneCapabilities.class]) {
         return array;
     } else {
         NSMutableArray* newList = [NSMutableArray arrayWithCapacity:[array count]];
         for (NSString* enumString in array) {
-            [newList addObject:[SDLHmiZoneCapabilities valueOf:enumString]];
+            [newList addObject:[SDLHMIZoneCapabilities valueOf:enumString]];
         }
         return newList;
     }


### PR DESCRIPTION
WARNING: This is a backward-incompatible change

The case of the file and class are different. This resolves that change by making the acronym for HMI fully uppercase, changing the class to match the file.