### PR TITLE
Fix additional full SmartDeviceLink.h file imports

### DIFF
--- a/sdl_ios/SmartDeviceLink/SDLConsoleController.m
+++ b/sdl_ios/SmartDeviceLink/SDLConsoleController.m
@@ -2,7 +2,7 @@
 //
 //  Copyright (c) 2014 Ford Motor Company. All rights reserved.
 
-#import <SmartDeviceLink/SmartDeviceLink.h>
+#import "SDLConsoleController.h"
 
 #import <SmartDeviceLink/SDLJSONEncoder.h>
 #import <SmartDeviceLink/SDLRPCResponse.h>

--- a/sdl_ios/SmartDeviceLink/SDLOnLockScreenStatus.h
+++ b/sdl_ios/SmartDeviceLink/SDLOnLockScreenStatus.h
@@ -3,8 +3,10 @@
 //  SmartDeviceLink
 //
 
-#import <SmartDeviceLink/SmartDeviceLink.h>
-#import "SDLLockScreenStatus.h"
+#import "SDLRPCNotification.h"
+
+@class SDLLockScreenStatus;
+@class SDLHMILevel;
 
 @interface SDLOnLockScreenStatus : SDLRPCNotification
 

--- a/sdl_ios/SmartDeviceLink/SDLOnLockScreenStatus.m
+++ b/sdl_ios/SmartDeviceLink/SDLOnLockScreenStatus.m
@@ -5,6 +5,9 @@
 
 #import "SDLOnLockScreenStatus.h"
 
+#import "SDLHMILevel.h"
+#import "SDLLockScreenStatus.h"
+
 @implementation SDLOnLockScreenStatus
 
 - (id)init {


### PR DESCRIPTION
Found additional places where the full `SmartDeviceLink.h` file is imported. It's completely unnecessary. Note that I also used `@class` syntax here. At some point, there will be a full audit, and `@class` syntax should be used just about everywhere.

Anticipated Pull Date: Jan 29, 2014 3pm EST