### PR TITLE
Follow best practices with SDLEnum comparisons

### DIFF
--- a/sdl_ios/SmartDeviceLink/SDLEnum.h
+++ b/sdl_ios/SmartDeviceLink/SDLEnum.h
@@ -10,6 +10,8 @@
 
 -(id) initWithValue:(NSString*) value;
 
+- (BOOL)isEqualToEnum:(SDLEnum *)object;
+
 @property(strong, readonly) NSString* value;
 
 @end

--- a/sdl_ios/SmartDeviceLink/SDLEnum.m
+++ b/sdl_ios/SmartDeviceLink/SDLEnum.m
@@ -19,4 +19,31 @@
 	return value;
 }
 
+- (NSUInteger)hash {
+    return [self.value hash];
+}
+
+- (BOOL)isEqual:(id)object {
+    // Test pointer equality
+    if (self == object) {
+        return YES;
+    }
+    
+    // Test class equality, if not equal, value equality doesn't matter
+    if (![object isMemberOfClass:self.class]) {
+        return NO;
+    }
+    
+    return [self isEqualToEnum:object];
+}
+
+- (BOOL)isEqualToEnum:(SDLEnum *)object {
+    // Test value equality, if it's equal we're good
+    if ([self.value isEqualToString:object.value]) {
+        return YES;
+    }
+    
+    return NO;
+}
+
 @end


### PR DESCRIPTION
Fixes #47 

Add an `-isEqualToEnum:` method to SDLEnum
Override `-hash` and` -isEqual` properly