### PR TITLE
Fix -[buildPutFileWithFileName:fileType:persisistentFile:correlationID:] misspelling

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCRequestFactory.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCRequestFactory.h
@@ -114,8 +114,8 @@ correlationID;
 +(SDLPerformInteraction*) buildPerformInteractionWithInitialPrompt:(NSString*)initialPrompt initialText:(NSString*)initialText interactionChoiceSetID:(NSNumber*) interactionChoiceSetID correlationID:(NSNumber*) correlationID;
 //*****
 
-
-+(SDLPutFile*) buildPutFileWithFileName:(NSString*) syncFileName fileType:(SDLFileType*) fileType persisistentFile:(NSNumber*) persistentFile correlationID:(NSNumber*) correlationID;
++(SDLPutFile*) buildPutFileWithFileName:(NSString*) fileName fileType:(SDLFileType*) fileType persistentFile:(NSNumber*) persistentFile correlationId:(NSNumber*) correlationID;
++(SDLPutFile*) buildPutFileWithFileName:(NSString*) syncFileName fileType:(SDLFileType*) fileType persisistentFile:(NSNumber*) persistentFile correlationID:(NSNumber*) correlationID __deprecated_msg("use buildPutFileWithFileName:fileType:persistentFile:correlationID: instead");
 
 +(SDLReadDID*) buildReadDIDWithECUName:(NSNumber*) ecuName didLocation:(NSArray*) didLocation correlationID:(NSNumber*) correlationID;
 

--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCRequestFactory.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLRPCRequestFactory.m
@@ -295,21 +295,23 @@ correlationID{
 }
 //*****
 
-
-+(SDLPutFile*) buildPutFileWithFileName:(NSString*) syncFileName fileType:(SDLFileType*) fileType persisistentFile:(NSNumber*) persistentFile correlationID:(NSNumber*) correlationID {
-    
++(SDLPutFile*) buildPutFileWithFileName:(NSString*) fileName fileType:(SDLFileType*) fileType persistentFile:(NSNumber*) persistentFile correlationId:(NSNumber*) correlationID {
     //TODO
     //    +(FMPutFile*) buildPutFile:(NSString*) syncFileName fileType:(SDLFileType*) fileType persisistentFile:(NSNumber*) persistentFile fileData:(NSData*) fileData correlationID:(NSNumber*) correlationID {
     
     
     SDLPutFile* msg = [[SDLPutFile alloc] init];
-    msg.syncFileName = syncFileName;
+    msg.syncFileName = fileName;
     
     msg.fileType = [fileType mutableCopy];
     msg.persistentFile = persistentFile;
     msg.correlationID = correlationID;
     
     return msg;
+}
+
++(SDLPutFile*) buildPutFileWithFileName:(NSString*) syncFileName fileType:(SDLFileType*) fileType persisistentFile:(NSNumber*) persistentFile correlationID:(NSNumber*) correlationID {
+    return [self buildPutFileWithFileName:syncFileName fileType:fileType persistentFile:persistentFile correlationId:correlationID];
 }
 
 +(SDLReadDID*) buildReadDIDWithECUName:(NSNumber*) ecuName didLocation:(NSArray*) didLocation correlationID:(NSNumber*) correlationID {


### PR DESCRIPTION
Remove 'sync' from "fileName" parameter
Change "correlationID" to "correlationId"

Deprecates previous method to be removed in a future major version.

Fixes #127