### PR TITLE
Enable quicklook introspection on SDLEnum objects

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLEnum.m
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLEnum.m
@@ -19,4 +19,8 @@
 	return value;
 }
 
+- (id)debugQuickLookObject {
+    return value;
+}
+
 @end


### PR DESCRIPTION
Exceedingly minor change that enables quick look introspection on sdlenum objects in the debugger. This way you don't have to print out each one to console.