### PR TITLE
Add documentation for SDLPrioritizedObjectCollection

### DIFF
--- a/SmartDeviceLink-iOS/SmartDeviceLink/SDLPrioritizedObjectCollection.h
+++ b/SmartDeviceLink-iOS/SmartDeviceLink/SDLPrioritizedObjectCollection.h
@@ -7,7 +7,21 @@
 
 @interface SDLPrioritizedObjectCollection : NSObject
 
+/**
+ * Add a new object to a push-pop collection. The object will be added in a location based on the priority passed in.
+ *
+ * A lower priority number is considered to be "higher". This is because this class is generally used with RPC service numbers, and lower services preempt higher ones.
+ *
+ * @param object   The object to be added to the priority collection
+ * @param priority The priority to use when determining the location of the object in the collection. A lower number is considered a higher priority
+ */
 - (void)addObject:(id)object withPriority:(NSInteger)priority;
-- (instancetype)nextObject;
+
+/**
+ * Retreive the highest priority object from the collection. This also removes the object.
+ *
+ * @return The highest priority object retrieved from the collection.
+ */
+- (id)nextObject;
 
 @end


### PR DESCRIPTION
Fix regression on return type on `nextObject` from `instancetype` to `id`

Fixes #143